### PR TITLE
Add Jest configuration and dark mode test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cd web-cv-project
 3. Install the dependencies:
 npm install
 
+4. Run the tests:
+npm test
+
 ## Technologies Used
 
 - HTML

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "web-curriculum-vitae",
+  "version": "1.0.0",
+  "description": "Web-based CV project",
+  "main": "scripts.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^21.1.0",
+    "jquery": "^3.7.1"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/scripts.test.js
+++ b/tests/scripts.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const jquery = require('jquery');
+
+function loadScript(window, filename) {
+  const scriptContent = fs.readFileSync(path.resolve(__dirname, '..', filename), 'utf8');
+  const scriptEl = window.document.createElement('script');
+  scriptEl.textContent = scriptContent;
+  window.document.body.appendChild(scriptEl);
+}
+
+test('dark mode toggle adds and removes class', () => {
+  const html = `<!DOCTYPE html><html><body><button id="dark-mode-toggle"></button></body></html>`;
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const { window } = dom;
+  const $ = jquery(window);
+  window.$ = window.jQuery = $;
+
+  loadScript(window, 'scripts.js');
+
+  const button = window.document.getElementById('dark-mode-toggle');
+  button.click();
+  expect(window.document.body.classList.contains('dark-mode')).toBe(true);
+  button.click();
+  expect(window.document.body.classList.contains('dark-mode')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- set up `package.json` with Jest and jsdom
- add test for dark mode toggle
- describe running `npm test` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fd69f2cc832d88fb18d8f2c1e1a7