### PR TITLE
Enhance CV content and project display

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,52 +54,82 @@
       <div class="timeline">
         <div class="timeline-item">
           <div class="timeline-content" data-aos="fade-right">
+            <img src="images/hwatt-logo2.png" alt="Company Logo">
+            <div>
+              <h3>Engineer &ndash; MSc thesis project</h3>
+              <p>Heriot-Watt University &ndash; Ocean Systems Laboratory</p>
+              <span>Feb 2025 - Aug 2025 | Edinburgh</span>
+            </div>
+          </div>
+          <div class="details">
+            <ul>
+              <li>Simulation et conception d&rsquo;un AUV pour l&rsquo;inspection offshore</li>
+              <li>Modélisation dynamique (6-DDL) et développement du contrôle</li>
+            </ul>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-content" data-aos="fade-left">
             <img src="images/ge-logo.png" alt="Company Logo">
             <div>
               <h3>IT engineer intern</h3>
               <p>General Electric</p>
-              <span>June 2023 - September 2023 | Paris</span>
+              <span>Jun 2023 - Sep 2023 | Paris</span>
             </div>
+          </div>
+          <div class="details">
+            <ul>
+              <li>Refonte de l&rsquo;architecture réseau – 100&nbsp;000&nbsp;&euro; d’économies annuelles</li>
+              <li>Supervision des environnements physiques et virtuels</li>
+              <li>R&D pour optimiser la gestion interne des données</li>
+            </ul>
           </div>
         </div>
         <div class="timeline-item">
-          <div class="timeline-content" data-aos="fade-left">
+          <div class="timeline-content" data-aos="fade-right">
             <img src="images/airbus-logo.png" alt="Company Logo">
             <div>
               <h3>Operator on the A350 XWB</h3>
               <p>Airbus</p>
-              <span>June 2021 - July 2021 | Toulouse</span>
+              <span>Jun 2021 - Jul 2021 | Toulouse</span>
             </div>
           </div>
-        </div>
-        <div class="timeline-item">
-          <div class="timeline-content" data-aos="fade-right">
-            <img src="images/aernnova-logo.png" alt="Company Logo">
-            <div>
-              <h3>Mechanical design engineer intern</h3>
-              <p>Aernnova</p>
-              <span>June 2017 - July 2017 | Madrid</span>
-            </div>
+          <div class="details">
+            <ul>
+              <li>Soutien à la ligne de production de l&rsquo;A350 XWB</li>
+              <li>Participation aux opérations d’aménagement cabine</li>
+            </ul>
           </div>
         </div>
         <div class="timeline-item">
           <div class="timeline-content" data-aos="fade-left">
-            <img src="images/logo-marine.png" alt="Company Logo">
+            <img src="images/aernnova-logo.png" alt="Company Logo">
             <div>
-              <h3>Intern</h3>
-              <p>French Navy</p>
-              <span>June 2017 - June 2017 | Brest</span>
+              <h3>Mechanical design intern</h3>
+              <p>Aernnova Aerospace</p>
+              <span>Jun 2018 - Jul 2018 | Madrid</span>
             </div>
+          </div>
+          <div class="details">
+            <ul>
+              <li>Observation de la conception des dérives et gouvernes Airbus</li>
+            </ul>
           </div>
         </div>
         <div class="timeline-item">
           <div class="timeline-content" data-aos="fade-right">
-            <img src="images/danone-logo.png" alt="Company Logo">
+            <img src="images/logo-marine.png" alt="Company Logo">
             <div>
-              <h3>Supply chain intern</h3>
-              <p>Danone</p>
-              <span>June 2016 - June 2016 | Madrid</span>
+              <h3>Technical internship</h3>
+              <p>Marine Nationale</p>
+              <span>Jun 2017 - Jul 2017 | Vigo/Brest</span>
             </div>
+          </div>
+          <div class="details">
+            <ul>
+              <li>Étude des systèmes embarqués&nbsp;: propulsion, sonar, radar, armement</li>
+              <li>Participation à la logistique de maintenance des unités navales</li>
+            </ul>
           </div>
         </div>
       </div>
@@ -108,16 +138,16 @@
       <h2>Education</h2>
       <div class="education-container">
         <div class="education-card" data-aos="flip-left">
-          <img src="images/ecam-logo.png" alt="University Logo">
-          <h3>Master of Science</h3>
-          <h4>Mechanical and Electrical Engineering</h4>
-          <p>Courses: Calculus, General Mechanics, Robotics, Signal Processing, etc.</p>
+          <img src="images/ecam-logo.png" alt="ECAM Lyon">
+          <h3>ECAM Lyon</h3>
+          <h4>Diplôme d'ingénieur génie mécanique et électrique (2020–2025)</h4>
+          <p>Robotique avancée, traitement de signal, asservissement, CAO, CFD, FEA…</p>
         </div>
         <div class="education-card" data-aos="flip-right">
-          <img src="images/hwatt-logo2.png" alt="University Logo">
-          <h3>Master of Science</h3>
-          <h4>Robotics</h4>
-          <p>Courses: To be determined</p>
+          <img src="images/hwatt-logo2.png" alt="Heriot-Watt University">
+          <h3>Heriot-Watt University</h3>
+          <h4>MSc Robotique (2024–2025)</h4>
+          <p>Robotique intelligente, systèmes embarqués, interaction humain-robot, IA pour la vision</p>
         </div>
       </div>
     </section>
@@ -144,10 +174,9 @@
           <h3>Languages</h3>
           <ul>
             <li>French - <div class="skill-level skill-level-100"></div></li>
-            <li>English - <div class="skill-level skill-level-100"></div></li>
-            <li>Spanish - <div class="skill-level skill-level-100"></div></li>
-            <li>Italian - <div class="skill-level skill-level-70"></div></li>
-            <li>Japanese - <div class="skill-level skill-level-10"></div></li>
+            <li>English (C2) - <div class="skill-level skill-level-100"></div></li>
+            <li>Spanish (C2) - <div class="skill-level skill-level-100"></div></li>
+            <li>Italian (B2) - <div class="skill-level skill-level-70"></div></li>
           </ul>
         </div>
       </div>
@@ -175,51 +204,49 @@
         <div class="project-card" data-category="robotics" data-aos="fade-up">
           <img src="images/photomakers.jpg" alt="Robotics project">
           <div class="project-info">
-            <h3>Robotic Systems Engineering</h3>
-            <p>Involved in multiple projects involving the conception of robots as part of the Robotics club at ECAM.</p>
+            <h3>Robotics Club Projects</h3>
+            <p>Involved in multiple projects designing robots as part of the ECAM robotics club.</p>
             <a href="#">View Project</a>
           </div>
         </div>
-        <div class="project-card extra-project hidden" data-category="web" data-aos="fade-up">
-          <img src="images/ecam-photo.png" alt="Portfolio">
+        <div class="project-card" data-category="robotics" data-aos="fade-up">
+          <img src="images/ecam-photo.png" alt="Robot competition">
           <div class="project-info">
-            <h3>Personal Portfolio</h3>
-            <p>Responsive portfolio built with modern web technologies to showcase my work.</p>
+            <h3>Coupe de France de Robotique &amp; Échiquier Robotisé</h3>
+            <p>Conception d&rsquo;un robot autonome pour la compétition et développement d&rsquo;un échiquier interactif.</p>
             <a href="#" target="_blank">View Project</a>
           </div>
         </div>
-        <div class="project-card extra-project hidden" data-category="data" data-aos="fade-up">
-          <img src="images/tbd.jpg" alt="Data dashboard">
+        <div class="project-card" data-category="robotics" data-aos="fade-up">
+          <img src="images/tbd.jpg" alt="Healthcare robot">
           <div class="project-info">
-            <h3>Data Visualization Dashboard</h3>
-            <p>Interactive dashboard for analyzing trends and visualizing metrics.</p>
+            <h3>Robot Assistant de Soins</h3>
+            <p>Implémentation de la navigation SLAM et de l&rsquo;interaction vocale pour la logistique hospitalière.</p>
             <a href="#" target="_blank">View Project</a>
           </div>
         </div>
-        <div class="project-card extra-project hidden" data-category="design" data-aos="fade-up">
-          <img src="images/tbd.jpg" alt="3D project">
+        <div class="project-card" data-category="data" data-aos="fade-up">
+          <img src="images/tbd.jpg" alt="Audio AI model">
           <div class="project-info">
-            <h3>3D Printed Drone</h3>
-            <p>Designed and fabricated a custom drone frame using CAD software and 3D printing.</p>
-            <a href="#" target="_blank">View Project</a>
-          </div>
-        </div>
-        <div class="project-card extra-project hidden" data-category="robotics" data-aos="fade-up">
-          <img src="images/tbd.jpg" alt="Rover">
-          <div class="project-info">
-            <h3>Autonomous Rover</h3>
-            <p>Built a rover platform equipped with sensors for autonomous navigation experiments.</p>
+            <h3>Modèle IA de Reconnaissance de sons</h3>
+            <p>Classification audio de plus de 100 espèces d&rsquo;oiseaux avec PyTorch et scikit-learn.</p>
             <a href="#" target="_blank">View Project</a>
           </div>
         </div>
       </div>
-      <button id="load-more">Load More</button>
       <div id="project-modal" class="modal">
         <div class="modal-content">
           <span class="close">&times;</span>
           <h3 id="modal-title"></h3>
           <p id="modal-desc"></p>
           <a id="modal-link" target="_blank">Visit</a>
+        </div>
+      </div>
+      <div id="experience-modal" class="modal">
+        <div class="modal-content">
+          <span class="close">&times;</span>
+          <h3 id="exp-modal-title"></h3>
+          <div id="exp-modal-desc"></div>
         </div>
       </div>
     </section>

--- a/scripts.js
+++ b/scripts.js
@@ -146,12 +146,6 @@ $(document).ready(function() {
   });
 
 
-  $('#load-more').on('click', function() {
-    $('.extra-project.hidden').slice(0, 2).removeClass('hidden').hide().fadeIn();
-    if ($('.extra-project.hidden').length === 0) {
-      $(this).hide();
-    }
-  });
 
   $('.project-card').on('click', function() {
     var title = $(this).find('h3').text();
@@ -170,6 +164,24 @@ $(document).ready(function() {
   $(window).on('click', function(e) {
     if ($(e.target).is('#project-modal')) {
       $('#project-modal').fadeOut();
+    }
+  });
+
+  $('.timeline-item').on('click', function() {
+    var title = $(this).find('h3').text();
+    var details = $(this).find('.details').html();
+    $('#exp-modal-title').text(title);
+    $('#exp-modal-desc').html(details);
+    $('#experience-modal').fadeIn();
+  });
+
+  $('#experience-modal .close').on('click', function() {
+    $('#experience-modal').fadeOut();
+  });
+
+  $(window).on('click', function(e) {
+    if ($(e.target).is('#experience-modal')) {
+      $('#experience-modal').fadeOut();
     }
   });
 

--- a/styles.css
+++ b/styles.css
@@ -549,6 +549,10 @@ body:not(.dark-mode) #toggle-thumb .fa-moon {
   display: none;
 }
 
+.details {
+  display: none;
+}
+
 #progress-bar {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- populate experience timeline with detailed info from CV
- update education details and language skills
- always display all project cards and remove load-more logic
- add modal to view full experience details

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444db7c1fc832d8957b033019f149e