### PR TITLE
Add mobile-friendly vertical timeline

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -220,20 +220,26 @@ section {
 
 @media (min-width: 900px) {
   .timeline {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 40px;
+    max-width: 900px;
   }
-  .timeline::before,
-  .timeline-item:nth-child(even)::before,
-  .timeline-item:nth-child(odd)::before {
-    display: none;
+}
+
+@media (max-width: 600px) {
+  .timeline::before {
+    left: 20px;
   }
   .timeline-item,
   .timeline-item:nth-child(even),
   .timeline-item:nth-child(odd) {
     width: 100%;
     left: 0;
+    padding-left: 40px;
+  }
+  .timeline-item::before,
+  .timeline-item:nth-child(even)::before,
+  .timeline-item:nth-child(odd)::before {
+    left: 10px;
+    right: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep timeline styling consistent across wider screens
- stack items on smaller screens for easier reading

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445ed7c0f0832d849fbbf6328545fc